### PR TITLE
correct fatal error cause by element selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 var postcss = require('postcss');
 
 function prepare( str, selectors, prefix ){
-	for(var i = 0; i < selectors.length; i++){
-		var idx = str.indexOf(selectors[i]);
-		if( idx > -1 ){
-			str = str.substr(0, idx +1) + prefix + str.substr(idx +1);
-		}
-	}
+    for(var i = 0; i < selectors.length; i++){
+        var idx = str.indexOf(selectors[i]);
+        if( idx > -1 ){
+            str = str.substr(0, idx +1) + prefix + str.substr(idx +1);
+        }
+    }
 
-	return str;
+    return str;
 }
 
 module.exports = postcss.plugin('postcss-selector-prefixer', function (opts) {
@@ -19,15 +19,16 @@ module.exports = postcss.plugin('postcss-selector-prefixer', function (opts) {
     return function (css, result) {
 
         css.walkRules(function (rule) {
-        	var selector = rule.selector,
-        		matches = selector.match( /(\s*?[#\.][-\w\d\s,\>\~\+\:\&]+\s*?)/g );
+            var selector = rule.selector,
+                matches = selector.match( /(\s*?[#\.][-\w\d\s,\>\~\+\:\&]+\s*?)/g );
 
-        	for(var i = 0; i < matches.length; i++){
-        		matches[i] = prepare(matches[i], selectors, prefix);
-        	}
+            if (matches !== null) {
+                for(var i = 0; i < matches.length; i++){
+                    matches[i] = prepare(matches[i], selectors, prefix);
+                }
 
-        	rule.selector = matches.join("");
-
+                rule.selector = matches.join("");
+            }
         });
 
     };


### PR DESCRIPTION
Adding element selector breaks build process
Fatal error: Cannot read property 'length' of null
eg:
.container {
color: red;
}
